### PR TITLE
Add csharpDark style

### DIFF
--- a/src/themes/csharpDark.ts
+++ b/src/themes/csharpDark.ts
@@ -1,8 +1,8 @@
 import { ITheme } from "./ITheme";
 
-export const csharpDark: ITheme = {
+export const CSharpDark: ITheme = {
   /** Display name */
-  DisplayName: 'csharpDark',
+  DisplayName: 'CSharpDark',
   /** Code styles */
   CodeStyles: {
     Keyword: {
@@ -49,6 +49,6 @@ export const csharpDark: ITheme = {
   },
   // Line number background colors
   LineNumberStyle: {
-    Color: 'e0e0e0
+    Color: 'e0e0e0'
   }
 }

--- a/src/themes/csharpDark.ts
+++ b/src/themes/csharpDark.ts
@@ -1,0 +1,54 @@
+import { ITheme } from "./ITheme";
+
+export const csharpDark: ITheme = {
+  /** Display name */
+  DisplayName: 'csharpDark',
+  /** Code styles */
+  CodeStyles: {
+    Keyword: {
+      Color: '569cd6'
+    },
+    Comment: {
+      Color: '56a64a'
+    },
+    Plaintext: {
+      Color: 'dedede'
+    },
+    Punctuation: {
+      Color: 'dedede'
+    },
+    String: {
+      Color: 'dadada'
+    },
+    Literal: {
+      Color: 'dadada'
+    },
+    Type: {
+      Color: '4ec9b0'
+    },
+    Tag: {
+      Color: 'd7bb7d'
+    },
+    AttributeName: {
+      Color: '4ec9b0'
+    },
+    AttributeValue: {
+      Color: '569cd6'
+    },
+    Decimal: {
+      Color: 'b5cea8'
+    },
+    NoCode: {
+      Color: '000',
+      BackgroundColor: 'none'
+    }
+  },
+  // Background color
+  BackgroundStyle: {
+    BackgroundColor: '1e1e1e'
+  },
+  // Line number background colors
+  LineNumberStyle: {
+    Color: 'e0e0e0
+  }
+}

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -8,6 +8,7 @@ import { A11YLight } from './A11YLight';
 import { AtelierCaveLight } from './AtelierCaveLight';
 import { AtelierCaveDark } from './AtelierCaveDark';
 import { BlueHintGray } from './BlueHintGray';
+import { csharpDark } from 'csharpDark';
 
 type ThemeDictionary = { [key: string]: ITheme };
 
@@ -41,7 +42,8 @@ export const Themes: ThemeDictionary = {
   A11YLight,
   AtelierCaveLight,
   AtelierCaveDark,
-  BlueHintGray
+  BlueHintGray,
+  csharpDark
 }
 
 export function GetLineNumberStyle(theme: string) {

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -8,7 +8,7 @@ import { A11YLight } from './A11YLight';
 import { AtelierCaveLight } from './AtelierCaveLight';
 import { AtelierCaveDark } from './AtelierCaveDark';
 import { BlueHintGray } from './BlueHintGray';
-import { csharpDark } from 'csharpDark';
+import { CSharpDark } from './CSharpDark';
 
 type ThemeDictionary = { [key: string]: ITheme };
 
@@ -43,7 +43,7 @@ export const Themes: ThemeDictionary = {
   AtelierCaveLight,
   AtelierCaveDark,
   BlueHintGray,
-  csharpDark
+  CSharpDark
 }
 
 export function GetLineNumberStyle(theme: string) {


### PR DESCRIPTION
there has been no style matching Visual Studio 2019 code styling used by csharp application development
expecting the color values in ITheme to be Hex code, matched the RGB Colors with google ColorPicker to get those values
maybe this style does mainly apply generally, only very few are only Lang specific
the cloned repository did not contain any executable so I was unable to test it locally