### PR TITLE
Add Thonny Default Light theme

### DIFF
--- a/src/themes/ThonnyDefaultLight.ts
+++ b/src/themes/ThonnyDefaultLight.ts
@@ -1,0 +1,35 @@
+import { ITheme } from "./ITheme";
+
+// Matches the thonny theme defined here:
+// https://github.com/thonny/thonny/blob/4fffa98e5c47e58ce72190c004f2ebc00879e4cd/thonny/plugins/base_syntax_themes.py#L5
+export const ThonnyDefaultLight: ITheme = {
+  DisplayName: 'Thonny Default Light',
+  CodeStyles: {
+    Keyword: {
+      Color: '7f0055',
+      FontWeight: 'bold'
+    },
+    Comment: {
+      Color: 'a9a9a9'
+    },
+    Plaintext: {
+      Color: '000000'
+    },
+    Punctuation: {
+      Color: '000000'
+    },
+    String: {
+      Color: '006400'
+    },
+    Literal: {
+      Color: 'b04600'
+    },
+    Type: {
+      Color: '7f0055'
+    }
+  },
+  BackgroundStyle: {},
+  LineNumberStyle: {
+    Background: 'none'
+  }
+};

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -9,6 +9,7 @@ import { AtelierCaveLight } from './AtelierCaveLight';
 import { AtelierCaveDark } from './AtelierCaveDark';
 import { BlueHintGray } from './BlueHintGray';
 import { ChatGPTDark } from './ChatGPTDark';
+import { ThonnyDefaultLight } from './ThonnyDefaultLight';
 
 type ThemeDictionary = { [key: string]: ITheme };
 
@@ -43,7 +44,8 @@ export const Themes: ThemeDictionary = {
   AtelierCaveLight,
   AtelierCaveDark,
   BlueHintGray,
-  ChatGPTDark
+  ChatGPTDark,
+  ThonnyDefaultLight,
 }
 
 export function GetLineNumberStyle(theme: string) {


### PR DESCRIPTION
Thanks for creating this plugin!

This PR adds the light theme of the Python Thonny text editor, which we use during Python courses. It would be convenient if we can format our python code in the guides we write exactly the same as the editor the students will be using.