### PR TITLE
Add UE Neon Candy Light and UE Aurora Pop Light themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-code-formatter-styles",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "A package which contains the styling details for easy code formatter.",
   "main": "dist/index.js",
   "repository": {

--- a/src/themes/UeAuroraPopLight.ts
+++ b/src/themes/UeAuroraPopLight.ts
@@ -1,0 +1,26 @@
+import { ITheme } from './ITheme';
+
+export const UeAuroraPopLight: ITheme = {
+  DisplayName: 'UE Aurora Pop Light',
+  CodeStyles: {
+    Keyword: { Color: '4f46e5', FontWeight: 'bold' },     
+    Comment: { Color: '16a34a', FontStyle: 'italic' },    
+    Plaintext: { Color: '111827' },                       
+    Punctuation: { Color: '334155' },                    
+    String: { Color: 'db2777' },                          
+    Literal: { Color: '8b5cf6' },                         
+    Type: { Color: '0891b2' },                            
+    Tag: { Color: '2563eb' },                             
+    AttributeName: { Color: '059669' },                   
+    AttributeValue: { Color: 'c026d3' },                  
+    Decimal: { Color: 'f59e0b' },                        
+    NoCode: { Color: '7c3aed' }, 
+  },
+  BackgroundStyle: {
+    BackgroundColor: 'fcfcff',
+  },
+  LineNumberStyle: {
+    Color: '64748b',
+    BackgroundColor: 'fcfcff',
+  },
+};

--- a/src/themes/UeNeonCandyLight.ts
+++ b/src/themes/UeNeonCandyLight.ts
@@ -1,0 +1,26 @@
+import { ITheme } from './ITheme';
+
+export const UeNeonCandyLight: ITheme = {
+  DisplayName: 'UE Neon Candy Light',
+  CodeStyles: {
+    Keyword: { Color: '7c4dff', FontWeight: 'bold' },    
+    Comment: { Color: '22a06b', FontStyle: 'italic' }, 
+    Plaintext: { Color: '1f2a44' }, 
+    Punctuation: { Color: '475569' }, 
+    String: { Color: 'ec4899' }, 
+    Literal: { Color: 'f59e0b' },                         
+    Type: { Color: '2563eb' },   
+    Tag: { Color: '6d28d9' },
+    AttributeName: { Color: '10b981' },
+    AttributeValue: { Color: 'd946ef' },
+    Decimal: { Color: 'f59e0b' },
+    NoCode: { Color: '0ea5e9' }, 
+  },
+  BackgroundStyle: {
+    BackgroundColor: 'ffffff',
+  },
+  LineNumberStyle: {
+    Color: '64748b',
+    BackgroundColor: 'ffffff',
+  },
+};

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -245,6 +245,8 @@ import { TokyoNightDark } from './TokyoNightDark';
 import { TokyoNightLight } from './TokyoNightLight';
 import { TomorrowNightBlue } from './TomorrowNightBlue';
 import { TomorrowNightBright } from './TomorrowNightBright';
+import { UeAuroraPopLight } from './UeAuroraPopLight';
+import { UeNeonCandyLight } from './UeNeonCandyLight';
 import { Vs } from './Vs';
 import { Vs2015 } from './Vs2015';
 import { XCode } from './XCode';
@@ -506,6 +508,8 @@ export const Themes: ThemeDictionary = {
   TokyoNightLight,
   TomorrowNightBlue,
   TomorrowNightBright,
+  UeAuroraPopLight,
+  UeNeonCandyLight,
   Vs,
   Vs2015,
   XCode,


### PR DESCRIPTION
Hi!
Added two new light themes intended for colorful code highlighting in Word dark mode workflows (where Word inverts page colors):

- UE Neon Candy Light
- UE Aurora Pop Light

Both themes use strong blues/greens/pinks/purples with a small orange accent.

Preview 
<img width="616" height="376" alt="image" src="https://github.com/user-attachments/assets/6d6b198a-ab2b-43ad-8475-452d8490289c" />
<img width="653" height="371" alt="image" src="https://github.com/user-attachments/assets/10a5d57d-9344-42f9-bac7-ae964e0163c1" />
[ue_theme_preview_full_palette_cpp.html](https://github.com/user-attachments/files/25495401/ue_theme_preview_full_palette_cpp.html)
